### PR TITLE
fix: remove .js and .jsx extensions from lint script

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "dev": "next dev -p 8080",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
+    "lint": "eslint . --ext .ts,.tsx",
     "test": "jest"
   },
   "dependencies": {


### PR DESCRIPTION
Linter is not configured to lint .js and .jsx files and hangs when script it ran. ESLint should be configured to lint .js and .jsx files if they become used for more than config files.