### PR TITLE
fix(theme): ensure Roboto font is applied correctly on button

### DIFF
--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -2,7 +2,7 @@ import { createTheme } from '@mui/material/styles';
 
 const commonSettings = {
   typography: {
-    fontFamily: 'Roboto, Arial, sans-serif, ',
+    fontFamily: 'Roboto',
     body1: {
       color: 'var(--common-white_states-main, #FFF)',
       fontFamily: 'Roboto',


### PR DESCRIPTION
- Remove "Arial, sans-serif" from fontFamily

Reason for change : 

- While working on the not-found page, I noticed that the Roboto font was not being applied to Button atom.
- Removing the extra font styles in Theme.ts fixed the bug.