### PR TITLE
feat(not-found)!: implement 404 page with dynamic link behavior

### DIFF
--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -10,8 +10,8 @@ export const NotFoundContent = () => {
   const router = useRouter();
 
   const [backLink, setBackLink] = useState('/');
-  const [linkLabel, setLinkLabel] = useState('Go to Home Page');
-  const [ariaLabel, setAriaLabel] = useState('Go to Home Page');
+  const [linkLabel, setLinkLabel] = useState('Go to Login');
+  const [ariaLabel, setAriaLabel] = useState('Go to Login');
 
   useEffect(() => {
     if (typeof window !== 'undefined' && document.referrer) {
@@ -21,13 +21,13 @@ export const NotFoundContent = () => {
       const initialBackLink =
         referrerOrigin === currentOrigin ? document.referrer : '/';
       const initialLinkLabel =
-        initialBackLink === '/' ? 'Go to Home Page' : 'Return to Previous Page';
+        initialBackLink === '/' ? 'Go to Login' : 'Return to Previous Page';
 
       setBackLink(initialBackLink);
       setLinkLabel(initialLinkLabel);
 
       const initialAriaLabel =
-        initialBackLink === '/' ? 'Go to Home Page' : 'Return to Previous Page';
+        initialBackLink === '/' ? 'Go to Login' : 'Return to Previous Page';
       setAriaLabel(initialAriaLabel);
     }
   }, []);

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,57 @@
+'use client';
+import { Container, Divider } from '@mui/material';
+import Link from '../../src/components/atoms/Link';
+import React from 'react';
+import Text from '../../src/components/atoms/Text';
+import dynamic from 'next/dynamic';
+
+const REDIRECT_ROUTE = '/';
+
+function NotFound() {
+  const backLink =
+    document.referrer &&
+    new URL(document.referrer).origin === window.location.origin
+      ? document.referrer
+      : REDIRECT_ROUTE;
+
+  const linkLabel = backLink === REDIRECT_ROUTE ? 'Go to login' : 'Go back';
+
+  return (
+    <Container
+      maxWidth="md"
+      style={{
+        padding: '2rem',
+        minHeight: '100vh',
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        textAlign: 'center',
+      }}
+    >
+      <div style={{ display: 'flex', alignItems: 'center', gap: '16px' }}>
+        <Text variant="h2">404</Text>
+        <Divider flexItem orientation="vertical" style={{ height: '40px' }} />
+        <Text variant="h2">Page not found.</Text>
+      </div>
+      <Link
+        href={backLink}
+        sx={{
+          marginTop: '1rem',
+          color: 'primary.main',
+          '&:hover': {
+            color: 'primary.dark',
+          },
+        }}
+      >
+        {linkLabel}
+      </Link>
+    </Container>
+  );
+}
+
+const DynamicNotFound = dynamic(() => Promise.resolve(NotFound), {
+  ssr: false,
+});
+
+export default DynamicNotFound;

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,20 +1,45 @@
 'use client';
 import { Container, Divider } from '@mui/material';
+import React, { useEffect, useState } from 'react';
 import Link from '../../src/components/atoms/Link';
-import React from 'react';
 import Text from '../../src/components/atoms/Text';
 import dynamic from 'next/dynamic';
+import { useRouter } from 'next/navigation';
 
-const REDIRECT_ROUTE = '/';
+export const NotFoundContent = () => {
+  const router = useRouter();
 
-function NotFound() {
-  const backLink =
-    document.referrer &&
-    new URL(document.referrer).origin === window.location.origin
-      ? document.referrer
-      : REDIRECT_ROUTE;
+  const [backLink, setBackLink] = useState('/');
+  const [linkLabel, setLinkLabel] = useState('Go to Home Page');
+  const [ariaLabel, setAriaLabel] = useState('Go to Home Page');
 
-  const linkLabel = backLink === REDIRECT_ROUTE ? 'Go to login' : 'Go back';
+  useEffect(() => {
+    if (typeof window !== 'undefined' && document.referrer) {
+      const referrerOrigin = new URL(document.referrer).origin;
+      const currentOrigin = window.location.origin;
+
+      const initialBackLink =
+        referrerOrigin === currentOrigin ? document.referrer : '/';
+      const initialLinkLabel =
+        initialBackLink === '/' ? 'Go to Home Page' : 'Return to Previous Page';
+
+      setBackLink(initialBackLink);
+      setLinkLabel(initialLinkLabel);
+
+      const initialAriaLabel =
+        initialBackLink === '/' ? 'Go to Home Page' : 'Return to Previous Page';
+      setAriaLabel(initialAriaLabel);
+    }
+  }, []);
+
+  const handleBack = (event: React.MouseEvent) => {
+    event.preventDefault();
+    if (backLink === document.referrer) {
+      router.back();
+    } else {
+      router.push(backLink);
+    }
+  };
 
   return (
     <Container
@@ -30,12 +55,14 @@ function NotFound() {
       }}
     >
       <div style={{ display: 'flex', alignItems: 'center', gap: '16px' }}>
-        <Text variant="h2">404</Text>
+        <Text variant="h1">404</Text>
         <Divider flexItem orientation="vertical" style={{ height: '40px' }} />
-        <Text variant="h2">Page not found.</Text>
+        <Text variant="h2">This page could not be found.</Text>
       </div>
       <Link
+        aria-label={ariaLabel}
         href={backLink}
+        onClick={handleBack}
         sx={{
           marginTop: '1rem',
           color: 'primary.main',
@@ -48,10 +75,10 @@ function NotFound() {
       </Link>
     </Container>
   );
-}
+};
 
-const DynamicNotFound = dynamic(() => Promise.resolve(NotFound), {
+const NotFound = dynamic(() => Promise.resolve(NotFoundContent), {
   ssr: false,
 });
 
-export default DynamicNotFound;
+export default NotFound;

--- a/tests/app/not-found.test.tsx
+++ b/tests/app/not-found.test.tsx
@@ -35,7 +35,7 @@ describe('NotFoundContent Component', () => {
     });
   });
 
-  it('should render "Go to Home Page" when there is no referrer', async () => {
+  it('should render "Go to Login" when there is no referrer', async () => {
     Object.defineProperty(window, 'location', {
       value: { origin: 'http://localhost' },
       writable: true,
@@ -44,7 +44,7 @@ describe('NotFoundContent Component', () => {
 
     render(<NotFoundContent />);
 
-    expect(await screen.findByText('Go to Home Page')).toBeInTheDocument();
+    expect(await screen.findByText('Go to Login')).toBeInTheDocument();
   });
 
   it('should render "Return to Previous Page" when referrer is from the same origin', async () => {
@@ -64,7 +64,7 @@ describe('NotFoundContent Component', () => {
     ).toBeInTheDocument();
   });
 
-  it('should render "Go to Home Page" when referrer is from a different origin', async () => {
+  it('should render "Go to Login" when referrer is from a different origin', async () => {
     Object.defineProperty(window, 'location', {
       value: { origin: 'http://localhost' },
       writable: true,
@@ -76,7 +76,7 @@ describe('NotFoundContent Component', () => {
 
     render(<NotFoundContent />);
 
-    expect(await screen.findByText('Go to Home Page')).toBeInTheDocument();
+    expect(await screen.findByText('Go to Login')).toBeInTheDocument();
   });
 
   it('clicking the link calls router.back() when backLink matches document.referrer', async () => {
@@ -111,7 +111,7 @@ describe('NotFoundContent Component', () => {
 
     render(<NotFoundContent />);
 
-    const linkElement = await screen.findByText('Go to Home Page');
+    const linkElement = await screen.findByText('Go to Login');
     fireEvent.click(linkElement);
 
     expect(mockPush).toHaveBeenCalledWith('/');

--- a/tests/app/not-found.test.tsx
+++ b/tests/app/not-found.test.tsx
@@ -1,44 +1,120 @@
 import '@testing-library/jest-dom';
-import { render, screen, waitFor } from '@testing-library/react';
-import DynamicNotFound from '../../src/app/not-found';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { NotFoundContent } from '../../src/app/not-found';
 import React from 'react';
+import { useRouter } from 'next/navigation';
 
-describe('NotFound Page', () => {
+jest.mock('next/navigation', () => ({
+  useRouter: jest.fn(),
+}));
+
+describe('NotFoundContent Component', () => {
+  const mockBack = jest.fn();
+  const mockPush = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useRouter as jest.Mock).mockReturnValue({
+      back: mockBack,
+      push: mockPush,
+    });
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
   it('should render the 404 message', async () => {
-    render(<DynamicNotFound />);
+    render(<NotFoundContent />);
+
     await waitFor(() => {
       expect(screen.getByText('404')).toBeInTheDocument();
-      expect(screen.getByText('Page not found.')).toBeInTheDocument();
+      expect(
+        screen.getByText('This page could not be found.')
+      ).toBeInTheDocument();
     });
   });
 
-  it('should render the Go to login link when there is no referrer', async () => {
-    Object.defineProperty(document, 'referrer', { value: '', writable: true });
-    render(<DynamicNotFound />);
-    await waitFor(() => {
-      expect(screen.getByText('Go to login')).toBeInTheDocument();
-    });
-  });
-
-  it('should render the Go back link when there is a referrer from the same origin', async () => {
-    Object.defineProperty(document, 'referrer', {
-      value: window.location.origin,
+  it('should render "Go to Home Page" when there is no referrer', async () => {
+    Object.defineProperty(window, 'location', {
+      value: { origin: 'http://localhost' },
       writable: true,
     });
-    render(<DynamicNotFound />);
-    await waitFor(() => {
-      expect(screen.getByText('Go back')).toBeInTheDocument();
-    });
+    Object.defineProperty(document, 'referrer', { value: '', writable: true });
+
+    render(<NotFoundContent />);
+
+    expect(await screen.findByText('Go to Home Page')).toBeInTheDocument();
   });
 
-  it('should render the Go to login link when the referrer is from a different origin', async () => {
+  it('should render "Return to Previous Page" when referrer is from the same origin', async () => {
+    Object.defineProperty(window, 'location', {
+      value: { origin: 'http://localhost' },
+      writable: true,
+    });
+    Object.defineProperty(document, 'referrer', {
+      value: 'http://localhost/previous-page',
+      writable: true,
+    });
+
+    render(<NotFoundContent />);
+
+    expect(
+      await screen.findByText('Return to Previous Page')
+    ).toBeInTheDocument();
+  });
+
+  it('should render "Go to Home Page" when referrer is from a different origin', async () => {
+    Object.defineProperty(window, 'location', {
+      value: { origin: 'http://localhost' },
+      writable: true,
+    });
     Object.defineProperty(document, 'referrer', {
       value: 'https://external.com',
       writable: true,
     });
-    render(<DynamicNotFound />);
-    await waitFor(() => {
-      expect(screen.getByText('Go to login')).toBeInTheDocument();
+
+    render(<NotFoundContent />);
+
+    expect(await screen.findByText('Go to Home Page')).toBeInTheDocument();
+  });
+
+  it('clicking the link calls router.back() when backLink matches document.referrer', async () => {
+    Object.defineProperty(window, 'location', {
+      value: { origin: 'http://localhost' },
+      writable: true,
     });
+    const referrer = 'http://localhost/previous-page';
+    Object.defineProperty(document, 'referrer', {
+      value: referrer,
+      writable: true,
+    });
+
+    render(<NotFoundContent />);
+
+    const linkElement = await screen.findByText('Return to Previous Page');
+    fireEvent.click(linkElement);
+
+    expect(mockBack).toHaveBeenCalled();
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  it('clicking the link calls router.push("/") when backLink does not match document.referrer', async () => {
+    Object.defineProperty(window, 'location', {
+      value: { origin: 'http://localhost' },
+      writable: true,
+    });
+    Object.defineProperty(document, 'referrer', {
+      value: '',
+      writable: true,
+    });
+
+    render(<NotFoundContent />);
+
+    const linkElement = await screen.findByText('Go to Home Page');
+    fireEvent.click(linkElement);
+
+    expect(mockPush).toHaveBeenCalledWith('/');
+    expect(mockBack).not.toHaveBeenCalled();
   });
 });

--- a/tests/app/not-found.test.tsx
+++ b/tests/app/not-found.test.tsx
@@ -1,0 +1,44 @@
+import '@testing-library/jest-dom';
+import { render, screen, waitFor } from '@testing-library/react';
+import DynamicNotFound from '../../src/app/not-found';
+import React from 'react';
+
+describe('NotFound Page', () => {
+  it('should render the 404 message', async () => {
+    render(<DynamicNotFound />);
+    await waitFor(() => {
+      expect(screen.getByText('404')).toBeInTheDocument();
+      expect(screen.getByText('Page not found.')).toBeInTheDocument();
+    });
+  });
+
+  it('should render the Go to login link when there is no referrer', async () => {
+    Object.defineProperty(document, 'referrer', { value: '', writable: true });
+    render(<DynamicNotFound />);
+    await waitFor(() => {
+      expect(screen.getByText('Go to login')).toBeInTheDocument();
+    });
+  });
+
+  it('should render the Go back link when there is a referrer from the same origin', async () => {
+    Object.defineProperty(document, 'referrer', {
+      value: window.location.origin,
+      writable: true,
+    });
+    render(<DynamicNotFound />);
+    await waitFor(() => {
+      expect(screen.getByText('Go back')).toBeInTheDocument();
+    });
+  });
+
+  it('should render the Go to login link when the referrer is from a different origin', async () => {
+    Object.defineProperty(document, 'referrer', {
+      value: 'https://external.com',
+      writable: true,
+    });
+    render(<DynamicNotFound />);
+    await waitFor(() => {
+      expect(screen.getByText('Go to login')).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
Overview :

- File Creation: Added not-found.tsx to handle and display 404 errors across the application.
- App-wide 404 Handling: Placing not-found.tsx directly in the app folder enables it to catch all 404 errors throughout the app.
- SSR Disabled: Disabled server-side rendering in not-found.tsx to improve user experience and resolve client-only errors, such as those related to document. (See [Stack Overflow reference](https://stackoverflow.com/questions/53139884/next-js-disable-server-side-rendering-on-some-pages))

Features :
useEffect Hook:
- When the component mounts, `useEffect` checks if the previous page (`document.referrer`) is within the same origin (domain) as the current page.
- If the previous page is within the same origin, `backLink` is set to `document.referrer` (previous page), and `linkLabel` is set to `'Return to Previous Page'`.
- Otherwise, the `backLink` remains `'/'` to direct users to the home page, and the label stays `'Go to login'`.

App wide error handling : 

NextJS supports a mechanism that lets one not-found page in the app folder catch errors throughout the application and sends back 404 error code.
( See Next Documentation on [[not-found page](https://nextjs.org/docs/app/api-reference/file-conventions/not-found)](https://nextjs.org/docs/app/api-reference/file-conventions/not-found) )

Use Cases

Use Case 1: Internal Navigation to a 404 Page
Example: A user clicks a broken link within the app, such as a link pointing to a page that doesn’t exist.
Behavior: The link label on the 404 page reads "Return to Previous Page", allowing the user to return to the last visited page.
Demo:
A user is on the home page, clicks a broken link to a non-existent URL, and is redirected to not-found.tsx. They see "404 Page not found" along with a link saying "Return to Previous Page", which takes them back to the home page.
If the user navigates from Home > About > [non-existent page], the link will return them to the About page.

https://github.com/user-attachments/assets/2c9e5d3c-1498-4054-83f9-119836878aaf

Use Case 2: Direct External Navigation to a 404 Page
Example: A user manually enters an incorrect URL as their initial page visit.
Behavior: The link label shows "Go to login", directing them to the default / page.
Demo:
A user enters a typo in the URL and lands on the 404 error page. They see "404 Page not found" with a link labeled "Go to login", which directs them to /.

https://github.com/user-attachments/assets/9b1b2ace-02eb-49e1-bb0c-43e14a8a6ef4


Summary

The not-found.tsx component effectively handles 404 errors across the application, adapting its behavior based on the user’s navigation path, with meaningful link labels and streamlined client-only rendering.

