### PR TITLE
feat(access)!: add useAccess hook and accessApi layer with tests

### DIFF
--- a/src/hooks/api/accessApi.ts
+++ b/src/hooks/api/accessApi.ts
@@ -227,7 +227,7 @@ const journal = (
   journalId: string,
   body?: JournalBody
 ): RequestBundle => {
-  const endpoint = `/journal/${journalId}`;
+  const endpoint = `/${journalId}`;
   return {
     endpoint,
     options: {

--- a/src/hooks/api/accessApi.ts
+++ b/src/hooks/api/accessApi.ts
@@ -3,11 +3,13 @@ import { RequestBundle } from '../useAccess';
 
 /**
  * Main API interface defining all available endpoint methods
+ *
  * @interface Api
  */
 interface Api {
   /**
    * Manages journal operations
+   *
    * @param method - HTTP method to be used
    * @param journalId - Unique identifier for the journal
    * @param body - Optional journal data
@@ -21,6 +23,7 @@ interface Api {
 
   /**
    * Manages account operations
+   *
    * @param method - HTTP method to be used
    * @param journalId - Unique identifier for the journal context
    * @param body - Account data to be processed
@@ -34,6 +37,7 @@ interface Api {
 
   /**
    * Handles user login
+   *
    * @param body - Login credentials
    * @returns {RequestBundle} Bundle containing endpoint and request options
    */
@@ -41,6 +45,7 @@ interface Api {
 
   /**
    * Handles token-based login
+   *
    * @param body - Token login data
    * @returns {RequestBundle} Bundle containing endpoint and request options
    */
@@ -48,6 +53,7 @@ interface Api {
 
   /**
    * Initiates password recovery process
+   *
    * @param body - Email information for password recovery
    * @returns {RequestBundle} Bundle containing endpoint and request options
    */
@@ -55,6 +61,7 @@ interface Api {
 
   /**
    * Handles password reset
+   *
    * @param body - New password and reset token
    * @returns {RequestBundle} Bundle containing endpoint and request options
    */
@@ -62,6 +69,7 @@ interface Api {
 
   /**
    * Handles user logout
+   *
    * @returns {RequestBundle} Bundle containing endpoint and request options
    */
   logout: () => RequestBundle;
@@ -76,6 +84,7 @@ interface Api {
 
 /**
  * Represents the body of a login request.
+ *
  * @property email - The email address of the user.
  * @property password - The password of the user.
  * @property remember - Whether the user's session should be remembered.
@@ -88,6 +97,7 @@ export interface LoginBody extends Record<string, unknown> {
 
 /**
  * Represents the body of a token-based login request.
+ *
  * @property token - The token used for authentication.
  */
 export interface TokenLoginBody extends Record<string, unknown> {
@@ -96,6 +106,7 @@ export interface TokenLoginBody extends Record<string, unknown> {
 
 /**
  * Represents the body of an account update request.
+ *
  * @property profile - Profile details of the user.
  * @property profile.fname - First name of the user.
  * @property profile.lname - Last name of the user.
@@ -127,6 +138,7 @@ interface AccountBody extends Record<string, unknown> {
 
 /**
  * Represents the body of a user registration request.
+ *
  * @property fname - First name of the user.
  * @property lname - Last name of the user.
  * @property email - Email address of the user.
@@ -141,6 +153,7 @@ export interface RegisterBody extends Record<string, unknown> {
 
 /**
  * Represents the body of a forgot password request.
+ *
  * @property email - The email address of the user requesting password recovery.
  */
 export interface ForgotPasswordBody extends Record<string, unknown> {
@@ -149,6 +162,7 @@ export interface ForgotPasswordBody extends Record<string, unknown> {
 
 /**
  * Represents the body of a reset password request.
+ *
  * @property newPassword - The new password for the user's account.
  * @property token - The token used to authorize the password reset.
  */
@@ -159,6 +173,7 @@ export interface ResetPasswordBody extends Record<string, unknown> {
 
 /**
  * Represents the body of a journal entry.
+ *
  * @property title - The title of the journal entry (optional).
  * @property description - The description or content of the journal entry (optional).
  */
@@ -169,6 +184,7 @@ export interface JournalBody extends Record<string, unknown> {
 
 /**
  * Creates a request bundle for user login
+ *
  * @param body - Login credentials and preferences
  * @returns {RequestBundle} Bundle containing endpoint and request options
  */
@@ -185,6 +201,7 @@ const login = (body: LoginBody): RequestBundle => {
 
 /**
  * Creates a request bundle for token-based login
+ *
  * @param body - Token login data
  * @returns {RequestBundle} Bundle containing endpoint and request options
  */
@@ -201,6 +218,7 @@ const tokenLogin = (body: TokenLoginBody): RequestBundle => {
 
 /**
  * Creates a request bundle for user registration
+ *
  * @param body - User registration information
  * @returns {RequestBundle} Bundle containing endpoint and request options
  */
@@ -217,6 +235,7 @@ const register = (body: RegisterBody): RequestBundle => {
 
 /**
  * Creates a request bundle for journal operations
+ *
  * @param method - HTTP method to be used
  * @param journalId - Unique identifier for the journal
  * @param body - Optional journal data
@@ -240,6 +259,7 @@ const journal = (
 
 /**
  * Creates a request bundle for account operations
+ *
  * @param method - HTTP method to be used
  * @param journalId - Unique identifier for the journal context
  * @param body - Account data to be processed
@@ -267,6 +287,7 @@ const account = (
 
 /**
  * Creates a request bundle for password recovery initiation
+ *
  * @param body - User's email information
  * @returns {RequestBundle} Bundle containing endpoint and request options
  */
@@ -283,6 +304,7 @@ const forgotPassword = (body: ForgotPasswordBody): RequestBundle => {
 
 /**
  * Creates a request bundle for password reset
+ *
  * @param body - New password and reset token
  * @returns {RequestBundle} Bundle containing endpoint and request options
  */
@@ -299,6 +321,7 @@ const resetPassword = (body: ResetPasswordBody): RequestBundle => {
 
 /**
  * Creates a request bundle for user logout
+ *
  * @returns {RequestBundle} Bundle containing endpoint and request options
  */
 const logout = (): RequestBundle => {
@@ -312,6 +335,10 @@ const logout = (): RequestBundle => {
   };
 };
 
+/**
+ * Object containing all available API endpoints for the components to
+ * reference.
+ */
 export const endpoints: Api = {
   journal,
   account,

--- a/src/hooks/api/accessApi.ts
+++ b/src/hooks/api/accessApi.ts
@@ -1,0 +1,324 @@
+import { Method } from '../apiRequest';
+import { RequestBundle } from '../useAccess';
+
+/**
+ * Main API interface defining all available endpoint methods
+ * @interface Api
+ */
+interface Api {
+  /**
+   * Manages journal operations
+   * @param method - HTTP method to be used
+   * @param journalId - Unique identifier for the journal
+   * @param body - Optional journal data
+   * @returns {RequestBundle} Bundle containing endpoint and request options
+   */
+  journal: (
+    method: Method,
+    journalId: string,
+    body?: JournalBody
+  ) => RequestBundle;
+
+  /**
+   * Manages account operations
+   * @param method - HTTP method to be used
+   * @param journalId - Unique identifier for the journal context
+   * @param body - Account data to be processed
+   * @returns {RequestBundle} Bundle containing endpoint and request options
+   */
+  account: (
+    method: Method,
+    journalId: string,
+    body: AccountBody
+  ) => RequestBundle;
+
+  /**
+   * Handles user login
+   * @param body - Login credentials
+   * @returns {RequestBundle} Bundle containing endpoint and request options
+   */
+  login: (body: LoginBody) => RequestBundle;
+
+  /**
+   * Handles token-based login
+   * @param body - Token login data
+   * @returns {RequestBundle} Bundle containing endpoint and request options
+   */
+  'token-login': (body: TokenLoginBody) => RequestBundle;
+
+  /**
+   * Initiates password recovery process
+   * @param body - Email information for password recovery
+   * @returns {RequestBundle} Bundle containing endpoint and request options
+   */
+  'forgot-password': (body: ForgotPasswordBody) => RequestBundle;
+
+  /**
+   * Handles password reset
+   * @param body - New password and reset token
+   * @returns {RequestBundle} Bundle containing endpoint and request options
+   */
+  'reset-password': (body: ResetPasswordBody) => RequestBundle;
+
+  /**
+   * Handles user logout
+   * @returns {RequestBundle} Bundle containing endpoint and request options
+   */
+  logout: () => RequestBundle;
+
+  /**
+   * Handles user registration
+   * @param body - Registration information
+   * @returns {RequestBundle} Bundle containing endpoint and request options
+   */
+  register: (body: RegisterBody) => RequestBundle;
+}
+
+/**
+ * Represents the body of a login request.
+ * @property email - The email address of the user.
+ * @property password - The password of the user.
+ * @property remember - Whether the user's session should be remembered.
+ */
+export interface LoginBody extends Record<string, unknown> {
+  email: string;
+  password: string;
+  remember: boolean;
+}
+
+/**
+ * Represents the body of a token-based login request.
+ * @property token - The token used for authentication.
+ */
+export interface TokenLoginBody extends Record<string, unknown> {
+  token: string;
+}
+
+/**
+ * Represents the body of an account update request.
+ * @property profile - Profile details of the user.
+ * @property profile.fname - First name of the user.
+ * @property profile.lname - Last name of the user.
+ * @property profile.email - Email address of the user.
+ * @property password - Password details of the user.
+ * @property password.oldPassword - The current password of the user.
+ * @property password.newPassword - The new password of the user.
+ * @property config - Configuration settings.
+ * @property config.model.chat - Chat model configuration.
+ * @property config.model.analysis - Analysis model configuration.
+ */
+interface AccountBody extends Record<string, unknown> {
+  profile: {
+    fname: string;
+    lname: string;
+    email: string;
+  };
+  password: {
+    oldPassword: string;
+    newPassword: string;
+  };
+  config: {
+    model: {
+      chat: string;
+      analysis: string;
+    };
+  };
+}
+
+/**
+ * Represents the body of a user registration request.
+ * @property fname - First name of the user.
+ * @property lname - Last name of the user.
+ * @property email - Email address of the user.
+ * @property password - The password for the new account.
+ */
+export interface RegisterBody extends Record<string, unknown> {
+  fname: string;
+  lname: string;
+  email: string;
+  password: string;
+}
+
+/**
+ * Represents the body of a forgot password request.
+ * @property email - The email address of the user requesting password recovery.
+ */
+export interface ForgotPasswordBody extends Record<string, unknown> {
+  email: string;
+}
+
+/**
+ * Represents the body of a reset password request.
+ * @property newPassword - The new password for the user's account.
+ * @property token - The token used to authorize the password reset.
+ */
+export interface ResetPasswordBody extends Record<string, unknown> {
+  newPassword: string;
+  token: string;
+}
+
+/**
+ * Represents the body of a journal entry.
+ * @property title - The title of the journal entry (optional).
+ * @property description - The description or content of the journal entry (optional).
+ */
+export interface JournalBody extends Record<string, unknown> {
+  title?: string;
+  description?: string;
+}
+
+/**
+ * Creates a request bundle for user login
+ * @param body - Login credentials and preferences
+ * @returns {RequestBundle} Bundle containing endpoint and request options
+ */
+const login = (body: LoginBody): RequestBundle => {
+  return {
+    endpoint: '/login',
+    options: {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body,
+    },
+  };
+};
+
+/**
+ * Creates a request bundle for token-based login
+ * @param body - Token login data
+ * @returns {RequestBundle} Bundle containing endpoint and request options
+ */
+const tokenLogin = (body: TokenLoginBody): RequestBundle => {
+  return {
+    endpoint: '/token-login',
+    options: {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body,
+    },
+  };
+};
+
+/**
+ * Creates a request bundle for user registration
+ * @param body - User registration information
+ * @returns {RequestBundle} Bundle containing endpoint and request options
+ */
+const register = (body: RegisterBody): RequestBundle => {
+  return {
+    endpoint: '/register',
+    options: {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body,
+    },
+  };
+};
+
+/**
+ * Creates a request bundle for journal operations
+ * @param method - HTTP method to be used
+ * @param journalId - Unique identifier for the journal
+ * @param body - Optional journal data
+ * @returns {RequestBundle} Bundle containing endpoint and request options
+ */
+const journal = (
+  method: Method,
+  journalId: string,
+  body?: JournalBody
+): RequestBundle => {
+  const endpoint = `/journal/${journalId}`;
+  return {
+    endpoint,
+    options: {
+      method,
+      headers: { 'Content-Type': 'application/json' },
+      body,
+    },
+  };
+};
+
+/**
+ * Creates a request bundle for account operations
+ * @param method - HTTP method to be used
+ * @param journalId - Unique identifier for the journal context
+ * @param body - Account data to be processed
+ * @throws {Error} When journal ID is not provided
+ * @returns {RequestBundle} Bundle containing endpoint and request options
+ */
+const account = (
+  method: Method,
+  journalId: string,
+  body: AccountBody
+): RequestBundle => {
+  if (!journalId) {
+    throw new Error('Journal ID is required but not provided.');
+  }
+
+  return {
+    endpoint: `/${journalId}/account`,
+    options: {
+      method,
+      headers: { 'Content-Type': 'application/json' },
+      body,
+    },
+  };
+};
+
+/**
+ * Creates a request bundle for password recovery initiation
+ * @param body - User's email information
+ * @returns {RequestBundle} Bundle containing endpoint and request options
+ */
+const forgotPassword = (body: ForgotPasswordBody): RequestBundle => {
+  return {
+    endpoint: '/forgot-password',
+    options: {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body,
+    },
+  };
+};
+
+/**
+ * Creates a request bundle for password reset
+ * @param body - New password and reset token
+ * @returns {RequestBundle} Bundle containing endpoint and request options
+ */
+const resetPassword = (body: ResetPasswordBody): RequestBundle => {
+  return {
+    endpoint: '/reset-password',
+    options: {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body,
+    },
+  };
+};
+
+/**
+ * Creates a request bundle for user logout
+ * @returns {RequestBundle} Bundle containing endpoint and request options
+ */
+const logout = (): RequestBundle => {
+  return {
+    endpoint: '/logout',
+    options: {
+      method: 'GET',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+    },
+  };
+};
+
+export const endpoints: Api = {
+  journal,
+  account,
+  login,
+  'token-login': tokenLogin,
+  'forgot-password': forgotPassword,
+  'reset-password': resetPassword,
+  logout,
+  register,
+};

--- a/src/hooks/api/accessApi.ts
+++ b/src/hooks/api/accessApi.ts
@@ -76,6 +76,7 @@ interface Api {
 
   /**
    * Handles user registration
+   *
    * @param body - Registration information
    * @returns {RequestBundle} Bundle containing endpoint and request options
    */
@@ -175,7 +176,8 @@ export interface ResetPasswordBody extends Record<string, unknown> {
  * Represents the body of a journal entry.
  *
  * @property title - The title of the journal entry (optional).
- * @property description - The description or content of the journal entry (optional).
+ * @property description - The description or content of the journal entry
+ * (optional).
  */
 export interface JournalBody extends Record<string, unknown> {
   title?: string;

--- a/src/hooks/apiRequest.ts
+++ b/src/hooks/apiRequest.ts
@@ -1,6 +1,4 @@
-type Method = 'GET' | 'POST' | 'PUT' | 'DELETE';
-
-const API_BASE_URL = process.env.NEXT_PUBLIC_BACKEND_URL;
+export type Method = 'GET' | 'POST' | 'PUT' | 'DELETE';
 
 const DEFAULT_OPTIONS: ApiOptions = {
   method: 'GET',
@@ -48,7 +46,7 @@ export const apiRequest = async <T>(
   url: string,
   options: ApiOptions = DEFAULT_OPTIONS
 ): Promise<T> => {
-  const response = await fetch(`${API_BASE_URL}${url}`, {
+  const response = await fetch(url, {
     ...(options as RequestInit),
     body: options.body && JSON.stringify(options.body),
   });

--- a/src/hooks/useAccess.ts
+++ b/src/hooks/useAccess.ts
@@ -24,6 +24,7 @@ export const useAccess = () => {
    * @returns {Promise<T>} Promise resolving to the response data
    * @throws {Error} When the API request fails
    * @returns {Promise<T>} Promise resolving to the response data or an error
+   */
   const request = async <T>(requestBundle: RequestBundle): Promise<T> => {
     const accessUri = `${ACCESS_BASE_URL}${requestBundle.endpoint}`;
 

--- a/src/hooks/useAccess.ts
+++ b/src/hooks/useAccess.ts
@@ -4,6 +4,7 @@ const ACCESS_BASE_URL = process.env.NEXT_PUBLIC_ACCESS_BASE_URL;
 
 /**
  * Interface representing the structure of an API request bundle
+ *
  * @interface RequestBundle
  */
 export interface RequestBundle {
@@ -12,6 +13,8 @@ export interface RequestBundle {
 }
 
 /**
+ * Custom hook for making API requests to the access API
+ *
  * @returns Object containing request method for making API calls
  */
 export const useAccess = () => {
@@ -20,17 +23,13 @@ export const useAccess = () => {
    * @param requestBundle - Bundle containing endpoint and request options
    * @returns {Promise<T>} Promise resolving to the response data
    * @throws {Error} When the API request fails
-   */
+   * @returns {Promise<T>} Promise resolving to the response data or an error
   const request = async <T>(requestBundle: RequestBundle): Promise<T> => {
-    try {
-      const accessUri = `${ACCESS_BASE_URL}${requestBundle.endpoint}`;
-      return await apiRequest<T>(accessUri, {
-        ...requestBundle.options,
-      });
-    } catch (error) {
-      console.error('Error in request:', error);
-      throw error;
-    }
+    const accessUri = `${ACCESS_BASE_URL}${requestBundle.endpoint}`;
+
+    return await apiRequest<T>(accessUri, {
+      ...requestBundle.options,
+    });
   };
 
   return { request };

--- a/src/hooks/useAccess.ts
+++ b/src/hooks/useAccess.ts
@@ -1,0 +1,37 @@
+import { ApiOptions, apiRequest } from './apiRequest';
+
+const ACCESS_BASE_URL = process.env.NEXT_PUBLIC_ACCESS_BASE_URL;
+
+/**
+ * Interface representing the structure of an API request bundle
+ * @interface RequestBundle
+ */
+export interface RequestBundle {
+  endpoint: string;
+  options: ApiOptions;
+}
+
+/**
+ * @returns Object containing request method for making API calls
+ */
+export const useAccess = () => {
+  /**
+   * @template T Type of the expected response data
+   * @param requestBundle - Bundle containing endpoint and request options
+   * @returns {Promise<T>} Promise resolving to the response data
+   * @throws {Error} When the API request fails
+   */
+  const request = async <T>(requestBundle: RequestBundle): Promise<T> => {
+    try {
+      const accessUri = `${ACCESS_BASE_URL}${requestBundle.endpoint}`;
+      return await apiRequest<T>(accessUri, {
+        ...requestBundle.options,
+      });
+    } catch (error) {
+      console.error('Error in request:', error);
+      throw error;
+    }
+  };
+
+  return { request };
+};

--- a/tests/hooks/api/accessApi.test.tsx
+++ b/tests/hooks/api/accessApi.test.tsx
@@ -1,0 +1,150 @@
+import { endpoints } from '../../../src/hooks/api/accessApi';
+
+const mockJournalId = '12345';
+const mockAccountBody = {
+  profile: {
+    fname: 'John',
+    lname: 'Doe',
+    email: 'john.doe@example.com',
+  },
+  password: {
+    oldPassword: 'old-password',
+    newPassword: 'new-password',
+  },
+  config: {
+    model: {
+      chat: 'gpt-4',
+      analysis: 'default',
+    },
+  },
+};
+
+describe('API Endpoints', () => {
+  test('login generates correct RequestBundle', () => {
+    const body = {
+      email: 'test@example.com',
+      password: 'password',
+      remember: true,
+    };
+    const result = endpoints.login(body);
+
+    expect(result).toEqual({
+      endpoint: '/login',
+      options: {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body,
+      },
+    });
+  });
+
+  test('token-login generates correct RequestBundle', () => {
+    const body = { token: 'test-token' };
+    const result = endpoints['token-login'](body);
+
+    expect(result).toEqual({
+      endpoint: '/token-login',
+      options: {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body,
+      },
+    });
+  });
+
+  test('register generates correct RequestBundle', () => {
+    const body = {
+      fname: 'John',
+      lname: 'Doe',
+      email: 'john.doe@example.com',
+      password: 'password',
+    };
+    const result = endpoints.register(body);
+
+    expect(result).toEqual({
+      endpoint: '/register',
+      options: {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body,
+      },
+    });
+  });
+
+  test('journal generates correct RequestBundle', () => {
+    const method = 'POST';
+    const body = { title: 'Journal Title', description: 'Description' };
+    const result = endpoints.journal(method, mockJournalId, body);
+
+    expect(result).toEqual({
+      endpoint: `/${mockJournalId}`,
+      options: {
+        method,
+        headers: { 'Content-Type': 'application/json' },
+        body,
+      },
+    });
+  });
+
+  test('account generates correct RequestBundle', () => {
+    const method = 'PUT';
+    const result = endpoints.account(method, mockJournalId, mockAccountBody);
+
+    expect(result).toEqual({
+      endpoint: `/${mockJournalId}/account`,
+      options: {
+        method,
+        headers: { 'Content-Type': 'application/json' },
+        body: mockAccountBody,
+      },
+    });
+  });
+
+  test('forgot-password generates correct RequestBundle', () => {
+    const body = { email: 'forgot@example.com' };
+    const result = endpoints['forgot-password'](body);
+
+    expect(result).toEqual({
+      endpoint: '/forgot-password',
+      options: {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body,
+      },
+    });
+  });
+
+  test('reset-password generates correct RequestBundle', () => {
+    const body = { newPassword: 'new-password', token: 'reset-token' };
+    const result = endpoints['reset-password'](body);
+
+    expect(result).toEqual({
+      endpoint: '/reset-password',
+      options: {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body,
+      },
+    });
+  });
+
+  test('logout generates correct RequestBundle', () => {
+    const result = endpoints.logout();
+
+    expect(result).toEqual({
+      endpoint: '/logout',
+      options: {
+        method: 'GET',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+      },
+    });
+  });
+
+  test('account throws an error when journalId is missing', () => {
+    const method = 'PUT';
+    expect(() => endpoints.account(method, '', mockAccountBody)).toThrow(
+      'Journal ID is required but not provided.'
+    );
+  });
+});

--- a/tests/hooks/apiRequest.test.tsx
+++ b/tests/hooks/apiRequest.test.tsx
@@ -1,4 +1,4 @@
-import { ApiOptions, apiRequest } from '../../../src/hooks/apiRequest';
+import { ApiOptions, apiRequest } from '../../src/hooks/apiRequest';
 
 global.fetch = jest.fn();
 

--- a/tests/hooks/apiRequest.test.tsx
+++ b/tests/hooks/apiRequest.test.tsx
@@ -18,9 +18,7 @@ describe('apiRequest', () => {
 
     const fetchCalls = (global.fetch as jest.Mock).mock.calls;
 
-    expect(fetchCalls[0][0]).toBe(
-      `${process.env.NEXT_PUBLIC_BACKEND_URL}/test-endpoint`
-    );
+    expect(fetchCalls[0][0]).toBe('/test-endpoint');
     expect(fetchCalls[0][1]).toMatchObject({
       method: 'GET',
       credentials: 'include',

--- a/tests/hooks/useAccess.test.tsx
+++ b/tests/hooks/useAccess.test.tsx
@@ -1,0 +1,51 @@
+import { apiRequest } from '../../src/hooks/apiRequest';
+import { renderHook } from '@testing-library/react';
+import { useAccess } from '../../src/hooks/useAccess';
+
+jest.mock('../../src/hooks/apiRequest', () => ({
+  apiRequest: jest.fn(),
+}));
+
+describe('useAccess Hook', () => {
+  test('request calls apiRequest with correct parameters', async () => {
+    const { result } = renderHook(() => useAccess());
+    const { request } = result.current;
+
+    const mockRequestBundle = {
+      endpoint: '/test-endpoint',
+      options: {
+        method: 'GET' as const,
+        headers: { 'Content-Type': 'application/json' },
+      },
+    };
+
+    const mockResponse = { data: 'test' };
+    (apiRequest as jest.Mock).mockResolvedValue(mockResponse);
+
+    const response = await request(mockRequestBundle);
+
+    expect(apiRequest).toHaveBeenCalledWith(
+      `${process.env.NEXT_PUBLIC_ACCESS_BASE_URL}/test-endpoint`,
+      mockRequestBundle.options
+    );
+    expect(response).toEqual(mockResponse);
+  });
+
+  test('request handles errors correctly', async () => {
+    const { result } = renderHook(() => useAccess());
+    const { request } = result.current;
+
+    const mockRequestBundle = {
+      endpoint: '/test-endpoint',
+      options: {
+        method: 'GET' as const,
+        headers: { 'Content-Type': 'application/json' },
+      },
+    };
+
+    const mockError = new Error('Test error');
+    (apiRequest as jest.Mock).mockRejectedValue(mockError);
+
+    await expect(request(mockRequestBundle)).rejects.toThrow('Test error');
+  });
+});


### PR DESCRIPTION
- Define the main API interface with methods in the accessApi layer.
- Add request bundle handlers for each endpoint and implement useAccess to make API calls dynamically.
- Remove `API_BASE_URL` environment variable from apiRequest and add `url` as a parameter for the function.
- Update the location of the hooks folder in the test suite to match the app directory structure.
- Add typedocs to each file.
- Add tests for the accessApi layer and useAccess hook.