### PR TITLE
feat(Input): add password visibility toggle

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "@babel/preset-env": "^7.25.4",
         "@babel/preset-react": "^7.24.7",
         "@babel/preset-typescript": "^7.24.7",
+        "@mui/icons-material": "^6.4.1",
         "@stylistic/eslint-plugin-ts": "^2.13.0",
         "@testing-library/jest-dom": "^6.5.0",
         "@testing-library/react": "^16.0.1",
@@ -2882,26 +2883,53 @@
       "license": "MIT"
     },
     "node_modules/@mui/core-downloads-tracker": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-6.4.0.tgz",
-      "integrity": "sha512-6u74wi+9zeNlukrCtYYET8Ed/n9AS27DiaXCZKAD3TRGFaqiyYSsQgN2disW83pI/cM1Q2lJY1JX4YfwvNtlNw==",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-6.4.1.tgz",
+      "integrity": "sha512-SfDLWMV5b5oXgDf3NTa2hCTPC1d2defhDH2WgFKmAiejC4mSfXYbyi+AFCLzpizauXhgBm8OaZy9BHKnrSpahQ==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mui-org"
       }
     },
+    "node_modules/@mui/icons-material": {
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-6.4.1.tgz",
+      "integrity": "sha512-wsxFcUTQxt4s+7Bg4GgobqRjyaHLmZGNOs+HJpbwrwmLbT6mhIJxhpqsKzzWq9aDY8xIe7HCjhpH7XI5UD6teA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.26.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@mui/material": "^6.4.1",
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@mui/material": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/@mui/material/-/material-6.4.0.tgz",
-      "integrity": "sha512-hNIgwdM9U3DNmowZ8mU59oFmWoDKjc92FqQnQva3Pxh6xRKWtD2Ej7POUHMX8Dwr1OpcSUlT2+tEMeLb7WYsIg==",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/@mui/material/-/material-6.4.1.tgz",
+      "integrity": "sha512-MFBfia6UiKxyoLeGkAh8M15bkeDmfnsUTMRJd/vTQue6YQ8AQ6lw9HqDthyYghzDEWIvZO/lQQzLrZE8XwNJLA==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.26.0",
-        "@mui/core-downloads-tracker": "^6.4.0",
-        "@mui/system": "^6.4.0",
+        "@mui/core-downloads-tracker": "^6.4.1",
+        "@mui/system": "^6.4.1",
         "@mui/types": "^7.2.21",
-        "@mui/utils": "^6.4.0",
+        "@mui/utils": "^6.4.1",
         "@popperjs/core": "^2.11.8",
         "@types/react-transition-group": "^4.4.12",
         "clsx": "^2.1.1",
@@ -2920,7 +2948,7 @@
       "peerDependencies": {
         "@emotion/react": "^11.5.0",
         "@emotion/styled": "^11.3.0",
-        "@mui/material-pigment-css": "^6.4.0",
+        "@mui/material-pigment-css": "^6.4.1",
         "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
         "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -2976,13 +3004,13 @@
       }
     },
     "node_modules/@mui/private-theming": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-6.4.0.tgz",
-      "integrity": "sha512-rNHci8MP6NOdEWAfZ/RBMO5Rhtp1T6fUDMSmingg9F1T6wiUeodIQ+NuTHh2/pMoUSeP9GdHdgMhMmfsXxOMuw==",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-6.4.1.tgz",
+      "integrity": "sha512-DcT7mwK89owwgcEuiE7w458te4CIjHbYWW6Kn6PiR6eLtxBsoBYphA968uqsQAOBQDpbYxvkuFLwhgk4bxoN/Q==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.26.0",
-        "@mui/utils": "^6.4.0",
+        "@mui/utils": "^6.4.1",
         "prop-types": "^15.8.1"
       },
       "engines": {
@@ -3037,16 +3065,16 @@
       }
     },
     "node_modules/@mui/system": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/@mui/system/-/system-6.4.0.tgz",
-      "integrity": "sha512-wTDyfRlaZCo2sW2IuOsrjeE5dl0Usrs6J7DxE3GwNCVFqS5wMplM2YeNiV3DO7s53RfCqbho+gJY6xaB9KThUA==",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/@mui/system/-/system-6.4.1.tgz",
+      "integrity": "sha512-rgQzgcsHCTtzF9MZ+sL0tOhf2ZBLazpjrujClcb4Siju5lTrK0xX4PsiropActzCemNfM+mOu+0jezAVnfRK8g==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.26.0",
-        "@mui/private-theming": "^6.4.0",
+        "@mui/private-theming": "^6.4.1",
         "@mui/styled-engine": "^6.4.0",
         "@mui/types": "^7.2.21",
-        "@mui/utils": "^6.4.0",
+        "@mui/utils": "^6.4.1",
         "clsx": "^2.1.1",
         "csstype": "^3.1.3",
         "prop-types": "^15.8.1"
@@ -3091,9 +3119,9 @@
       }
     },
     "node_modules/@mui/utils": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-6.4.0.tgz",
-      "integrity": "sha512-woOTATWNsTNR3YBh2Ixkj3l5RaxSiGoC9G8gOpYoFw1mZM77LWJeuMHFax7iIW4ahK0Cr35TF9DKtrafJmOmNQ==",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-6.4.1.tgz",
+      "integrity": "sha512-iQUDUeYh87SvR4lVojaRaYnQix8BbRV51MxaV6MBmqthecQoxwSbS5e2wnbDJUeFxY2ppV505CiqPLtd0OWkqw==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.26.0",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@babel/preset-env": "^7.25.4",
     "@babel/preset-react": "^7.24.7",
     "@babel/preset-typescript": "^7.24.7",
+    "@mui/icons-material": "^6.4.1",
     "@stylistic/eslint-plugin-ts": "^2.13.0",
     "@testing-library/jest-dom": "^6.5.0",
     "@testing-library/react": "^16.0.1",

--- a/src/components/atoms/Input.tsx
+++ b/src/components/atoms/Input.tsx
@@ -1,8 +1,10 @@
 'use client';
 
+import { IconButton, InputAdornment } from '@mui/material';
+import React, { useState } from 'react';
+import { Visibility, VisibilityOff } from '@mui/icons-material';
 import { InputProps } from '@components/atoms/Input';
 import { TextField as MuiInput } from '@mui/material';
-import React from 'react';
 
 const Input: React.FC<InputProps> = ({
   label,
@@ -20,8 +22,21 @@ const Input: React.FC<InputProps> = ({
   ariaLabel,
   ariaLabelledBy,
   tabIndex,
+  showPasswordToggle = false,
   ...props
 }: InputProps) => {
+  const [showPassword, setShowPassword] = useState(false);
+
+  const handleClickShowPassword = () => {
+    setShowPassword(!showPassword);
+  };
+
+  const handleMouseDownPassword = (
+    event: React.MouseEvent<HTMLButtonElement>
+  ) => {
+    event.preventDefault();
+  };
+
   return (
     <MuiInput
       disabled={disabled}
@@ -36,13 +51,26 @@ const Input: React.FC<InputProps> = ({
         input: {
           'aria-label': ariaLabel,
           'aria-labelledby': ariaLabelledBy,
+          endAdornment:
+            type === 'password' && showPasswordToggle ? (
+              <InputAdornment position="end">
+                <IconButton
+                  aria-label="toggle password visibility"
+                  onClick={handleClickShowPassword}
+                  onMouseDown={handleMouseDownPassword}
+                  edge="end"
+                >
+                  {showPassword ? <Visibility /> : <VisibilityOff />}{' '}
+                </IconButton>
+              </InputAdornment>
+            ) : undefined,
         },
         htmlInput: {
           tabIndex: tabIndex,
         },
       }}
       sx={sx}
-      type={type}
+      type={showPassword ? 'text' : type}
       value={value}
       variant={variant}
       {...props}

--- a/src/components/atoms/Input.tsx
+++ b/src/components/atoms/Input.tsx
@@ -31,12 +31,6 @@ const Input: React.FC<InputProps> = ({
     setShowInput(!showInput);
   };
 
-  const handleMouseDownShowInput = (
-    event: React.MouseEvent<HTMLButtonElement>
-  ) => {
-    event.preventDefault();
-  };
-
   return (
     <MuiInput
       disabled={disabled}
@@ -51,19 +45,17 @@ const Input: React.FC<InputProps> = ({
         input: {
           'aria-label': ariaLabel,
           'aria-labelledby': ariaLabelledBy,
-          endAdornment:
-            hideInput ? (
-              <InputAdornment position="end">
-                <IconButton
-                  aria-label="toggle input visibility"
-                  onClick={handleClickShowInput}
-                  onMouseDown={handleMouseDownShowInput}
-                  edge="end"
-                >
-                  {showInput ? <Visibility /> : <VisibilityOff />}{' '}
-                </IconButton>
-              </InputAdornment>
-            ) : undefined,
+          endAdornment: hideInput ? (
+            <InputAdornment position="end">
+              <IconButton
+                aria-label="toggle input visibility"
+                onClick={handleClickShowInput}
+                edge="end"
+              >
+                {showInput ? <Visibility /> : <VisibilityOff />}{' '}
+              </IconButton>
+            </InputAdornment>
+          ) : undefined,
         },
         htmlInput: {
           tabIndex: tabIndex,

--- a/src/components/atoms/Input.tsx
+++ b/src/components/atoms/Input.tsx
@@ -22,16 +22,16 @@ const Input: React.FC<InputProps> = ({
   ariaLabel,
   ariaLabelledBy,
   tabIndex,
-  showPasswordToggle = false,
+  hideInput = false,
   ...props
 }: InputProps) => {
-  const [showPassword, setShowPassword] = useState(false);
+  const [showInput, setShowInput] = useState(false);
 
-  const handleClickShowPassword = () => {
-    setShowPassword(!showPassword);
+  const handleClickShowInput = () => {
+    setShowInput(!showInput);
   };
 
-  const handleMouseDownPassword = (
+  const handleMouseDownShowInput = (
     event: React.MouseEvent<HTMLButtonElement>
   ) => {
     event.preventDefault();
@@ -52,15 +52,15 @@ const Input: React.FC<InputProps> = ({
           'aria-label': ariaLabel,
           'aria-labelledby': ariaLabelledBy,
           endAdornment:
-            type === 'password' && showPasswordToggle ? (
+            hideInput ? (
               <InputAdornment position="end">
                 <IconButton
-                  aria-label="toggle password visibility"
-                  onClick={handleClickShowPassword}
-                  onMouseDown={handleMouseDownPassword}
+                  aria-label="toggle input visibility"
+                  onClick={handleClickShowInput}
+                  onMouseDown={handleMouseDownShowInput}
                   edge="end"
                 >
-                  {showPassword ? <Visibility /> : <VisibilityOff />}{' '}
+                  {showInput ? <Visibility /> : <VisibilityOff />}{' '}
                 </IconButton>
               </InputAdornment>
             ) : undefined,
@@ -70,7 +70,7 @@ const Input: React.FC<InputProps> = ({
         },
       }}
       sx={sx}
-      type={showPassword ? 'text' : type}
+      type={showInput ? 'text' : type}
       value={value}
       variant={variant}
       {...props}

--- a/src/types/Input.types.d.ts
+++ b/src/types/Input.types.d.ts
@@ -19,7 +19,7 @@ declare module '@components/atoms/Input' {
     tabIndex?: number;
     ariaLabel?: string;
     ariaLabelledBy?: string;
-    showPasswordToggle?: boolean;
+    hideInput?: boolean;
   }
 
   const Input: FC<InputProps>;

--- a/src/types/Input.types.d.ts
+++ b/src/types/Input.types.d.ts
@@ -19,6 +19,7 @@ declare module '@components/atoms/Input' {
     tabIndex?: number;
     ariaLabel?: string;
     ariaLabelledBy?: string;
+    showPasswordToggle?: boolean;
   }
 
   const Input: FC<InputProps>;

--- a/tests/components/atoms/Input.test.tsx
+++ b/tests/components/atoms/Input.test.tsx
@@ -72,42 +72,27 @@ describe('Input component', () => {
     expect(input.rows).toBe(3);
   });
 
-  it('should show a password toggle button when showPasswordToggle is true', () => {
-    render(<Input {...defaultProps} type="password" showPasswordToggle />);
+  it('should show an input toggle button when hideInput is true', () => {
+    render(<Input {...defaultProps} type="password" hideInput />);
     const input = screen.getByLabelText('Test Input') as HTMLInputElement;
     expect(input.type).toBe('password');
 
-    const passwordToggle = screen.getByLabelText('toggle password visibility');
-    expect(passwordToggle).toBeInTheDocument();
+    const inputToggle = screen.getByLabelText('toggle input visibility');
+    expect(inputToggle).toBeInTheDocument();
 
-    fireEvent.click(passwordToggle);
+    fireEvent.click(inputToggle);
     expect(input.type).toBe('text');
 
-    fireEvent.click(passwordToggle);
+    fireEvent.click(inputToggle);
     expect(input.type).toBe('password');
   });
 
-  it('should not show a password toggle button when showPasswordToggle is false', () => {
-    render(
-      <Input {...defaultProps} type="password" showPasswordToggle={false} />
-    );
+  it('should not show an input toggle button when hideInput is false', () => {
+    render(<Input {...defaultProps} type="password" hideInput={false} />);
     const input = screen.getByLabelText('Test Input') as HTMLInputElement;
     expect(input.type).toBe('password');
 
-    const passwordToggle = screen.queryByLabelText(
-      'toggle password visibility'
-    );
-    expect(passwordToggle).not.toBeInTheDocument();
-  });
-
-  it('should not show a password toggle button for non-password types', () => {
-    render(<Input {...defaultProps} type="text" showPasswordToggle />);
-    const input = screen.getByLabelText('Test Input') as HTMLInputElement;
-    expect(input.type).toBe('text');
-
-    const passwordToggle = screen.queryByLabelText(
-      'toggle password visibility'
-    );
-    expect(passwordToggle).not.toBeInTheDocument();
+    const inputToggle = screen.queryByLabelText('toggle input visibility');
+    expect(inputToggle).not.toBeInTheDocument();
   });
 });

--- a/tests/components/atoms/Input.test.tsx
+++ b/tests/components/atoms/Input.test.tsx
@@ -71,4 +71,43 @@ describe('Input component', () => {
     expect(input.tagName.toLowerCase()).toBe('textarea');
     expect(input.rows).toBe(3);
   });
+
+  it('should show a password toggle button when showPasswordToggle is true', () => {
+    render(<Input {...defaultProps} type="password" showPasswordToggle />);
+    const input = screen.getByLabelText('Test Input') as HTMLInputElement;
+    expect(input.type).toBe('password');
+
+    const passwordToggle = screen.getByLabelText('toggle password visibility');
+    expect(passwordToggle).toBeInTheDocument();
+
+    fireEvent.click(passwordToggle);
+    expect(input.type).toBe('text');
+
+    fireEvent.click(passwordToggle);
+    expect(input.type).toBe('password');
+  });
+
+  it('should not show a password toggle button when showPasswordToggle is false', () => {
+    render(
+      <Input {...defaultProps} type="password" showPasswordToggle={false} />
+    );
+    const input = screen.getByLabelText('Test Input') as HTMLInputElement;
+    expect(input.type).toBe('password');
+
+    const passwordToggle = screen.queryByLabelText(
+      'toggle password visibility'
+    );
+    expect(passwordToggle).not.toBeInTheDocument();
+  });
+
+  it('should not show a password toggle button for non-password types', () => {
+    render(<Input {...defaultProps} type="text" showPasswordToggle />);
+    const input = screen.getByLabelText('Test Input') as HTMLInputElement;
+    expect(input.type).toBe('text');
+
+    const passwordToggle = screen.queryByLabelText(
+      'toggle password visibility'
+    );
+    expect(passwordToggle).not.toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
- Implement TextField endAdorment for password fields.
- Add showPasswordToggle prop.
- Add `@mui/icons-material` to devDependencies.
- Integrate Visibility/VisibilityOff MUI icons.
- Create test for password toggle feature.

## How to use :
1) Import the atom :
 `import Input from '@components/atoms/Input';`
2) Set showPasswordToggle to true and keep type = "password" : 
              `<Input
                label="Password"
                name="password"
                type="password"
                showPasswordToggle={true}
              />`

## Preview :

1) Toggle off :
![image](https://github.com/user-attachments/assets/048e741e-180e-4b26-bf8b-5e1267526ef0)

2) Toggle on : 
![image](https://github.com/user-attachments/assets/20ec1845-81f7-46cd-972b-b9b211801d1c)
