### PR TITLE
refactor: update entry `endpoints` naming convention

### DIFF
--- a/src/hooks/api/entryApi.ts
+++ b/src/hooks/api/entryApi.ts
@@ -180,7 +180,7 @@ interface Api {
    * @param body - Entry analysis body
    * @returns 
    */
-  entryAnalysis: (
+  'entry-analysis': (
     method: Method,
     entryId: string,
     body?: EntryAnalysisBody
@@ -194,7 +194,7 @@ interface Api {
    * @param body - Entry conversation body
    * @returns 
    */
-  entryConversation: (
+  'entry-conversation': (
     method: Method,
     entryId: string,
     chatId?: string,
@@ -282,6 +282,6 @@ const entryConversation = (
  */
 export const endpoints: Api = {
   entry,
-  entryAnalysis,
-  entryConversation,
+  'entry-analysis': entryAnalysis,
+  'entry-conversation': entryConversation,
 };

--- a/tests/hooks/api/entryApi.test.tsx
+++ b/tests/hooks/api/entryApi.test.tsx
@@ -94,7 +94,7 @@ describe('Entry API Endpoints', () => {
     };
 
     test('generates correct RequestBundle for PUT', () => {
-      const result = endpoints.entryAnalysis(
+      const result = endpoints['entry-analysis'](
         'PUT',
         mockEntryId,
         mockAnalysisBody
@@ -112,7 +112,7 @@ describe('Entry API Endpoints', () => {
     });
 
     test('generates correct RequestBundle for GET', () => {
-      const result = endpoints.entryAnalysis('GET', mockEntryId);
+      const result = endpoints['entry-analysis']('GET', mockEntryId);
 
       expect(result).toEqual({
         endpoint: `/${mockEntryId}/analysis`,
@@ -138,7 +138,7 @@ describe('Entry API Endpoints', () => {
     };
 
     test('generates correct RequestBundle for POST without chatId', () => {
-      const result = endpoints.entryConversation(
+      const result = endpoints['entry-conversation'](
         'POST',
         mockEntryId,
         undefined,
@@ -157,7 +157,7 @@ describe('Entry API Endpoints', () => {
     });
 
     test('generates correct RequestBundle for GET with chatId', () => {
-      const result = endpoints.entryConversation(
+      const result = endpoints['entry-conversation'](
         'GET',
         mockEntryId,
         mockChatId
@@ -175,7 +175,7 @@ describe('Entry API Endpoints', () => {
     });
 
     test('generates correct RequestBundle for PUT with chatId', () => {
-      const result = endpoints.entryConversation(
+      const result = endpoints['entry-conversation'](
         'PUT',
         mockEntryId,
         mockChatId,
@@ -369,7 +369,7 @@ describe.skip('entryApi Integration Tests', () => {
       analysis_content: 'Updated analysis for integration testing.',
     };
 
-    const request = endpoints.entryAnalysis('PUT', entryId, body);
+    const request = endpoints['entry-analysis']('PUT', entryId, body);
     const response = await makeRequest(
       `${API_BASE_URL}/journals/${journalId}/entries/${entryId}/analysis`,
       {
@@ -412,7 +412,7 @@ describe.skip('entryApi Integration Tests', () => {
       ],
     };
 
-    const request = endpoints.entryConversation(
+    const request = endpoints['entry-conversation'](
       'POST',
       entryId,
       undefined,


### PR DESCRIPTION
Use kebab case to match server endpoint naming convention.
- Update `entryAnalysis` to `entry-analysis`.
- Update `entryConversation` to `entry-conversation`.
- Update tests to use bracket notation to access properties of `endpoints`.