### PR TITLE
feat(FlashContext)!: implement flash message support

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,8 @@ import '@fontsource/roboto/500.css';
 import '@fontsource/roboto/700.css';
 import { AppRouterCacheProvider } from '@mui/material-nextjs/v13-appRouter';
 import { CssBaseline } from '@mui/material';
+import { FlashComponent } from '../components/utils/FlashComponent';
+import { FlashProvider } from '../contexts/FlashProvider';
 import { JournalProvider } from '../contexts/JournalProvider';
 import React from 'react';
 import { ThemeProvider } from '../theme/ThemeContext';
@@ -18,9 +20,12 @@ export default function RootLayout({
       <body>
         <ThemeProvider>
           <CssBaseline />
-          <JournalProvider>
-            <AppRouterCacheProvider>{children}</AppRouterCacheProvider>
-          </JournalProvider>
+          <FlashProvider>
+            <FlashComponent /> 
+            <JournalProvider>
+              <AppRouterCacheProvider>{children}</AppRouterCacheProvider>
+            </JournalProvider>
+          </FlashProvider>
         </ThemeProvider>
       </body>
     </html>

--- a/src/components/utils/FlashComponent.tsx
+++ b/src/components/utils/FlashComponent.tsx
@@ -1,58 +1,77 @@
 'use client';
-import { Alert, Collapse, IconButton } from '@mui/material';
+import { Alert, IconButton, Snackbar } from '@mui/material';
 import { useEffect, useState } from 'react';
 import CloseIcon from '@mui/icons-material/Close';
+import { FlashMessage } from '@/contexts/FlashContext';
 import React from 'react';
 import { useFlash } from '../../contexts/useFlash';
 
 /**
- * A component that displays a flash message using MUI's `Alert` API.
- * Automatically dismisses after 5 seconds or can be manually closed.
- * Uses Material-UI's `Collapse` for animation and `Alert` for displaying messages.
+ * A component that displays a flash message using MUI's `Alert` and `Snackbar`.
+ * Automatically dismisses after a duration dynamically 
+ * calculated based on message length.
  * @see {@link https://mui.com/material-ui/react-alert/|MUI Alert}
  * @see {@link https://mui.com/material-ui/api/collapse/|MUI Collapse}
  */
-
 export const FlashComponent = () => {
   const { flash, clearFlash } = useFlash();
-  const [open, setOpen] = useState(false);
+  const [messages, setMessages] = useState<FlashMessage[]>([]);
 
   useEffect(() => {
     if (flash) {
-      setOpen(true);
+      setMessages((prevMessages) => [...prevMessages, flash]);
+
+      const timeout = Math.min(5000 + flash.message.length * 50, 15000);
 
       const timer = setTimeout(() => {
-        setOpen(false);
+        setMessages((prevMessages) => prevMessages.slice(1));
         clearFlash();
-      }, 5000);
+      }, timeout);
 
-      return () => clearTimeout(timer);
+      return () => clearTimeout(timer); 
     }
   }, [flash, clearFlash]);
 
-  if (!flash) return null;
-
   return (
-    <Collapse in={open}>
-      <Alert
-        severity={flash.type}
-        sx={{ margin: '1rem' }}
-        action={
-          <IconButton
-            aria-label="close"
-            color="inherit"
-            size="small"
-            onClick={() => {
-              setOpen(false);
-              clearFlash();
+    <>
+      {messages.map((msg, index) => {
+        const autoHideDuration = Math.min(5000 + msg.message.length * 50, 15000);
+
+        return (
+          <Snackbar
+            key={index}
+            open={true}
+            autoHideDuration={autoHideDuration}
+            onClose={() => setMessages((prev) => prev.filter((_, i) => i !== index))}
+            anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
+            sx={{
+              width: '100%',
+              maxWidth: 'calc(100vw - 40px)',
+              margin: '0 auto',
             }}
           >
-            <CloseIcon fontSize="inherit" />
-          </IconButton>
-        }
-      >
-        {flash.message}
-      </Alert>
-    </Collapse>
+            <Alert
+              severity={msg.type}
+              sx={{
+                width: '100%',
+                borderRadius: 1,
+              }}
+              action={
+                <IconButton
+                  aria-label="close"
+                  color="inherit"
+                  size="small"
+                  onClick={() => setMessages((prev) => prev.filter((_, i) => i !== index))}
+                >
+                  <CloseIcon fontSize="inherit" />
+                </IconButton>
+              }
+            >
+              {msg.message}
+            </Alert>
+          </Snackbar>
+        );
+      })}
+    </>
   );
 };

--- a/src/components/utils/FlashComponent.tsx
+++ b/src/components/utils/FlashComponent.tsx
@@ -1,0 +1,50 @@
+'use client';
+import { Alert, Collapse, IconButton } from '@mui/material';
+import { useEffect, useState } from 'react';
+import CloseIcon from '@mui/icons-material/Close';
+import React from 'react';
+import { useFlash } from '../../contexts/useFlash';
+
+export const FlashComponent = () => {
+  const { flash, clearFlash } = useFlash();
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    if (flash) {
+      setOpen(true);
+
+      const timer = setTimeout(() => {
+        setOpen(false);
+        clearFlash();
+      }, 5000);
+
+      return () => clearTimeout(timer);
+    }
+  }, [flash, clearFlash]);
+
+  if (!flash) return null;
+
+  return (
+    <Collapse in={open}>
+      <Alert
+        severity={flash.type}
+        sx={{ margin: '1rem' }}
+        action={
+          <IconButton
+            aria-label="close"
+            color="inherit"
+            size="small"
+            onClick={() => {
+              setOpen(false);
+              clearFlash();
+            }}
+          >
+            <CloseIcon fontSize="inherit" />
+          </IconButton>
+        }
+      >
+        {flash.message}
+      </Alert>
+    </Collapse>
+  );
+};

--- a/src/components/utils/FlashComponent.tsx
+++ b/src/components/utils/FlashComponent.tsx
@@ -5,6 +5,14 @@ import CloseIcon from '@mui/icons-material/Close';
 import React from 'react';
 import { useFlash } from '../../contexts/useFlash';
 
+/**
+ * A component that displays a flash message using MUI's `Alert` API.
+ * Automatically dismisses after 5 seconds or can be manually closed.
+ * Uses Material-UI's `Collapse` for animation and `Alert` for displaying messages.
+ * @see {@link https://mui.com/material-ui/react-alert/|MUI Alert}
+ * @see {@link https://mui.com/material-ui/api/collapse/|MUI Collapse}
+ */
+
 export const FlashComponent = () => {
   const { flash, clearFlash } = useFlash();
   const [open, setOpen] = useState(false);

--- a/src/contexts/FlashContext.ts
+++ b/src/contexts/FlashContext.ts
@@ -1,0 +1,41 @@
+import { createContext } from 'react';
+
+/**
+ * The type for the flash message.
+ * @typeParam success - A successful flash message.
+ * @typeParam error - An error flash message.
+ * @typeParam info - An informational flash message.
+ */
+export type FlashMessageType = 'success' | 'error' | 'info' | 'warning';
+
+/**
+ * The type for the flash message.
+ * @typeParam type - The type of flash message.
+ * @typeParam message - The message to display.
+ */
+export interface FlashMessage {
+  type: FlashMessageType; 
+  message: string;
+}
+
+/**
+ * The context type for the Flash.
+ * @typeParam flash - The current flash message.
+ * @typeParam setFlash - A function to update the flash.
+ * @typeParam clearFlash - A function to clear the flash.
+ * @typeParam processFlash - A function to process flash messages.
+ */
+export interface FlashContextType {
+  flash: FlashMessage | null;
+  setFlash: (value: FlashMessage) => void;
+  clearFlash: () => void;
+  processFlash: (data: any) => void;
+}
+
+/**
+ * The React Context for the flash feature providing access to the 
+ * `flash`, `setFlash` and `clearFlash` functions.
+ */
+export const FlashContext = createContext<FlashContextType | undefined>(
+  undefined
+);

--- a/src/contexts/FlashContext.ts
+++ b/src/contexts/FlashContext.ts
@@ -5,6 +5,7 @@ import { createContext } from 'react';
  * @typeParam success - A successful flash message.
  * @typeParam error - An error flash message.
  * @typeParam info - An informational flash message.
+ * @typeParam warning - A warning flash message.
  */
 export type FlashMessageType = 'success' | 'error' | 'info' | 'warning';
 
@@ -34,7 +35,7 @@ export interface FlashContextType {
 
 /**
  * The React Context for the flash feature providing access to the 
- * `flash`, `setFlash` and `clearFlash` functions.
+ * related functions.
  */
 export const FlashContext = createContext<FlashContextType | undefined>(
   undefined

--- a/src/contexts/FlashProvider.tsx
+++ b/src/contexts/FlashProvider.tsx
@@ -1,0 +1,80 @@
+'use client';
+import { FlashContext, FlashContextType, FlashMessage } from './FlashContext';
+import { ReactNode, useCallback, useState } from 'react';
+import React from 'react';
+
+/**
+ * The props for the FlashProvider component.
+ * @typeParam children - The React children.
+ */
+interface FlashProviderProps {
+  children: ReactNode;
+}
+
+/**
+ * The provider for the flash feature.
+ * @param children - The React children.
+ * @returns The React component.
+ */
+export const FlashProvider = ({ children }: FlashProviderProps) => {
+  const [flash, setFlash] = useState<FlashMessage | null>(null);
+
+  /**
+   * A function to clear the flash message.
+   */
+  const clearFlash = useCallback(() => setFlash(null), []);
+
+  /**
+   * A function to handle flash messages.
+   * @param flashData - The flash
+   * data to process.
+   * @returns The processed flash messages.
+   */
+  const handleFlashMessages = (flashData: any) => {
+    Object.entries(flashData).forEach(([type, messages]) => {
+      if (['success', 'error', 'info', 'warning'].includes(type)) {
+        (messages as string[]).forEach((message) => {
+          setFlash({ type: type as FlashMessage['type'], message });
+        });
+      }
+    });
+  };
+
+  /**
+   * A function to process flash messages.
+   * @param data - The data to process.
+   */
+  const processFlash = useCallback((data: any) => {
+    try {
+      if (data?.flash) {
+        handleFlashMessages(data.flash);
+      }
+
+      if (typeof data?.message === 'string') {
+        try {
+          const parsedMessage = JSON.parse(data.message);
+          if (parsedMessage?.flash) {
+            handleFlashMessages(parsedMessage.flash);
+          } else {
+            setFlash({ type: 'error', message: 'An unexpected error occurred.' });
+          }
+        } catch {
+          setFlash({ type: 'error', message: 'An unexpected error occurred.' });
+        }
+      }
+    } catch {
+      setFlash({ type: 'error', message: 'An unexpected error occurred.' });
+    }
+  }, []);
+
+  const value: FlashContextType = {
+    flash,
+    setFlash,
+    clearFlash,
+    processFlash,
+  };
+
+  return (
+    <FlashContext.Provider value={value}>{children}</FlashContext.Provider>
+  );
+};

--- a/src/contexts/useFlash.ts
+++ b/src/contexts/useFlash.ts
@@ -1,0 +1,15 @@
+import { FlashContext } from './FlashContext';
+import { useContext } from 'react';
+
+/**
+ * Custom hook to access the Flash context within a `FlashProvider`.
+ * @returns The `flash`, `setFlash`, `clearFlash` and `processFlash` from the `FlashContext`.
+ * @throws An error if used outside a `FlashProvider`.
+ */
+export const useFlash = () => {
+  const context = useContext(FlashContext);
+  if (!context) {
+    throw new Error('useFlash must be used within a FlashProvider');
+  }
+  return context;
+};

--- a/src/hooks/useAccess.ts
+++ b/src/hooks/useAccess.ts
@@ -1,25 +1,56 @@
 import { RequestBundle, apiRequest } from './apiRequest';
+import { FlashContext } from '../contexts/FlashContext';
+import { useContext } from 'react';
 
-const ACCESS_BASE_URL = process.env.NEXT_PUBLIC_ACCESS_BASE_URL;
 
 /**
  * Custom hook for making API requests to the access API
- * @returns Object containing request method for making API calls
+ * @returns Object containing a request method for making API calls
  */
 export const useAccess = () => {
-  /**
-   * @typeParam T - The type of the response data
-   * @param requestBundle - Bundle containing endpoint and request options
-   * @throws An error When the API request fails
-   * @returns A promise resolving to the response data
-   * @returns A Promise resolving to the response data or an error
-   */
-  const request = async <T>(requestBundle: RequestBundle): Promise<T> => {
-    const accessUri = `${ACCESS_BASE_URL}${requestBundle.endpoint}`;
+  const flashContext = useContext(FlashContext);
 
-    return await apiRequest<T>(accessUri, {
-      ...requestBundle.options,
-    });
+  if (!flashContext) {
+    throw new Error('useAccess must be used within a FlashProvider');
+  }
+  const { processFlash } = flashContext;
+
+  /**
+   * Processes API errors and extracts flash messages
+   * @param error - The API error
+   * @returns The extracted flash message or a default error message
+   */  
+  const handleError = (error: any) => {
+    try {
+      const errorResponse = JSON.parse(error.message);
+      return errorResponse?.flash ? errorResponse : { flash: { error: ['An unexpected error occurred.'] } };
+    } catch {
+      return { flash: { error: ['An unexpected error occurred.'] } };
+    }
+  };
+
+  /**
+   * Makes an API request and processes flash messages from the response.
+   * @typeParam T - The expected response data type.
+   * @param requestBundle - Bundle containing endpoint and request options.
+   * @returns A Promise resolving to the response data.
+   * @throws An error if the API request fails.
+   */
+  const request = async <T extends object>(requestBundle: RequestBundle): Promise<T> => {
+    const accessUri = `${process.env.NEXT_PUBLIC_ACCESS_BASE_URL}${requestBundle.endpoint}`;
+
+    try {
+      const response = await apiRequest<T>(accessUri, { ...requestBundle.options });
+
+      if (response && typeof response === 'object' && 'flash' in response) {
+        processFlash(response);
+      }
+
+      return response;
+    } catch (error: any) {
+      processFlash(handleError(error));
+      throw error;
+    }
   };
 
   return { request };

--- a/src/hooks/useEntry.ts
+++ b/src/hooks/useEntry.ts
@@ -1,6 +1,6 @@
 import { RequestBundle, apiRequest } from './apiRequest';
-
-const ENTRY_BASE_URL = process.env.NEXT_PUBLIC_ENTRY_BASE_URL;
+import { FlashContext } from '../contexts/FlashContext';
+import { useContext } from 'react';
 
 /**
  * Custom hook for making API requests to the entry API
@@ -29,6 +29,28 @@ export const useEntry = (journalId: string) => {
   if (!journalId) {
     throw new Error('journalId is required to use useEntry.');
   }
+
+  const flashContext = useContext(FlashContext);
+  
+  if (!flashContext) {
+    throw new Error('useEntry must be used within a FlashProvider');
+  }
+
+  const { processFlash } = flashContext;
+
+  /**
+   * Processes API errors and extracts flash messages
+   * @param error - The API error
+   * @returns The extracted flash message or a default error message
+   */
+  const handleError = (error: any) => {
+    try {
+      const errorResponse = JSON.parse(error.message);
+      return errorResponse?.flash ? errorResponse : { flash: { error: ['An unexpected error occurred.'] } };
+    } catch {
+      return { flash: { error: ['An unexpected error occurred.'] } };
+    }
+  };
   
   /**
    * @typeParam T - The type of the response data
@@ -36,11 +58,20 @@ export const useEntry = (journalId: string) => {
    * @returns A Promise resolving to the response data or an error
    */
   const request = async <T>(requestBundle: RequestBundle): Promise<T> => {
-    const entryUri = `${ENTRY_BASE_URL}/${journalId}/entries${requestBundle.endpoint}`;
+    const entryUri = `${process.env.NEXT_PUBLIC_ENTRY_BASE_URL}/${journalId}/entries${requestBundle.endpoint}`;
 
-    return await apiRequest<T>(entryUri, {
-      ...requestBundle.options,
-    });
+    try {
+      const response = await apiRequest<T>(entryUri, { ...requestBundle.options });
+
+      if (response && typeof response === 'object' && 'flash' in response) {
+        processFlash(response);
+      }
+
+      return response;
+    } catch (error: any) {
+      processFlash(handleError(error));
+      throw error;
+    }
   };
 
   return { request };

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -94,6 +94,14 @@ const commonSettings = {
         },
       },
     },
+    MuiAlert: {
+      styleOverrides: {
+        root: {
+          fontSize: '16px',
+          fontFamily: 'Roboto',
+        },
+      },
+    },
   },
 };
 

--- a/tests/components/utils/FlashComponent.test.tsx
+++ b/tests/components/utils/FlashComponent.test.tsx
@@ -1,0 +1,101 @@
+import '@testing-library/jest-dom';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { FlashComponent } from '../../../src/components/utils/FlashComponent';
+import React from 'react';
+import { useFlash } from '../../../src/contexts/useFlash';
+
+// Mock the useFlash context
+jest.mock('../../../src/contexts/useFlash');
+
+describe('FlashComponent', () => {
+  let mockClearFlash: jest.Mock;
+  let mockUseFlash: jest.Mock;
+
+  beforeEach(() => {
+    mockClearFlash = jest.fn();
+    mockUseFlash = jest.fn(() => ({
+      flash: null,
+      clearFlash: mockClearFlash,
+    }));
+    (useFlash as jest.Mock).mockImplementation(mockUseFlash);
+  });
+
+  it('should not render anything if there is no flash message', () => {
+    render(<FlashComponent />);
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  it('should render a flash message with the correct text and severity', () => {
+    (useFlash as jest.Mock).mockReturnValue({
+      flash: { message: 'Success!', type: 'success' },
+      clearFlash: mockClearFlash,
+    });
+
+    render(<FlashComponent />);
+    expect(screen.getByRole('alert')).toHaveTextContent('Success!');
+    expect(screen.getByRole('alert')).toHaveClass('MuiAlert-root'); // MUI class check
+  });
+
+  it('should close the alert when close button is clicked', () => {
+    (useFlash as jest.Mock).mockReturnValue({
+      flash: { message: 'Error occurred', type: 'error' },
+      clearFlash: mockClearFlash,
+    });
+
+    render(<FlashComponent />);
+    const closeButton = screen.getByRole('button', { name: /close/i });
+
+    fireEvent.click(closeButton);
+
+    expect(mockClearFlash).toHaveBeenCalledTimes(1);
+  });
+
+  it('should auto-dismiss the flash message after 5 seconds', () => {
+    jest.useFakeTimers();
+
+    (useFlash as jest.Mock).mockReturnValue({
+      flash: { message: 'Auto-dismiss test', type: 'info' },
+      clearFlash: mockClearFlash,
+    });
+
+    render(<FlashComponent />);
+
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+
+    act(() => {
+      jest.advanceTimersByTime(5000);
+    });
+
+    expect(mockClearFlash).toHaveBeenCalledTimes(1);
+  });
+
+  it('should keep the alert visible before 5 seconds and disappear afterward', () => {
+    jest.useFakeTimers();
+
+    (useFlash as jest.Mock).mockReturnValue({
+      flash: { message: 'Delayed test', type: 'warning' },
+      clearFlash: mockClearFlash,
+    });
+
+    render(<FlashComponent />);
+
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+
+    act(() => {
+      jest.advanceTimersByTime(3000);
+    });
+
+    expect(screen.getByRole('alert')).toBeInTheDocument(); // Still visible
+
+    act(() => {
+      jest.advanceTimersByTime(2000);
+    });
+
+    expect(mockClearFlash).toHaveBeenCalledTimes(1);
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.resetAllMocks();
+  });
+});

--- a/tests/contexts/FlashContext.test.tsx
+++ b/tests/contexts/FlashContext.test.tsx
@@ -1,0 +1,189 @@
+import '@testing-library/jest-dom';
+import { act, render, screen } from '@testing-library/react';
+import { FlashProvider } from '../../src/contexts/FlashProvider';
+import React from 'react';
+import { useFlash } from '../../src/contexts/useFlash';
+
+// A test component to interact with the FlashContext
+const TestComponent = () => {
+  const { flash, setFlash, clearFlash, processFlash } = useFlash();
+
+  return (
+    <div>
+      <button onClick={() => setFlash({ type: 'success', message: 'Success!' })}>Set Success Flash</button>
+      <button onClick={() => setFlash({ type: 'warning', message: 'Warning!' })}>Set Warning Flash</button>
+      <button onClick={() => setFlash({ type: 'info', message: 'Information!' })}>Set Info Flash</button>
+      <button onClick={clearFlash}>Clear Flash</button>
+      <button onClick={() => processFlash({ flash: { error: ['Error occurred!'] } })}>Process Error Flash</button>
+      <button onClick={() => processFlash({ flash: { warning: ['Warning alert!'] } })}>Process Warning Flash</button>
+      <button onClick={() => processFlash({ message: JSON.stringify({ info: ['Info message!'] }) })}>Process JSON Without Flash</button>
+      <button onClick={() => processFlash({ message: JSON.stringify({ flash: { success: [], error: [] } }) })}>Process Empty Messages</button>
+      <button onClick={() => processFlash({ flash: { error: ['First error'], success: ['Second success'] } })}>Process Multiple Flash Types</button>
+      {flash && <div data-testid="flash-message">{flash.message}</div>}
+    </div>
+  );
+};
+
+describe('FlashContext', () => {
+  test('sets a success flash message', () => {
+    render(
+      <FlashProvider>
+        <TestComponent />
+      </FlashProvider>
+    );
+
+    act(() => {
+      screen.getByText('Set Success Flash').click();
+    });
+
+    expect(screen.getByTestId('flash-message')).toHaveTextContent('Success!');
+  });
+
+  test('sets a warning flash message', () => {
+    render(
+      <FlashProvider>
+        <TestComponent />
+      </FlashProvider>
+    );
+
+    act(() => {
+      screen.getByText('Set Warning Flash').click();
+    });
+
+    expect(screen.getByTestId('flash-message')).toHaveTextContent('Warning!');
+  });
+
+  test('sets an info flash message', () => {
+    render(
+      <FlashProvider>
+        <TestComponent />
+      </FlashProvider>
+    );
+
+    act(() => {
+      screen.getByText('Set Info Flash').click();
+    });
+
+    expect(screen.getByTestId('flash-message')).toHaveTextContent('Information!');
+  });
+
+  test('clears the flash message', () => {
+    render(
+      <FlashProvider>
+        <TestComponent />
+      </FlashProvider>
+    );
+
+    act(() => {
+      screen.getByText('Set Success Flash').click();
+    });
+
+    expect(screen.getByTestId('flash-message')).toHaveTextContent('Success!');
+
+    act(() => {
+      screen.getByText('Clear Flash').click();
+    });
+
+    expect(screen.queryByTestId('flash-message')).toBeNull();
+  });
+
+  test('processes flash data and sets an error message', () => {
+    render(
+      <FlashProvider>
+        <TestComponent />
+      </FlashProvider>
+    );
+
+    act(() => {
+      screen.getByText('Process Error Flash').click();
+    });
+
+    expect(screen.getByTestId('flash-message')).toHaveTextContent('Error occurred!');
+  });
+
+  test('processes flash data and sets a warning message', () => {
+    render(
+      <FlashProvider>
+        <TestComponent />
+      </FlashProvider>
+    );
+
+    act(() => {
+      screen.getByText('Process Warning Flash').click();
+    });
+
+    expect(screen.getByTestId('flash-message')).toHaveTextContent('Warning alert!');
+  });
+
+  test('handles JSON without flash property', () => {
+    render(
+      <FlashProvider>
+        <TestComponent />
+      </FlashProvider>
+    );
+
+    act(() => {
+      screen.getByText('Process JSON Without Flash').click();
+    });
+
+    expect(screen.getByTestId('flash-message')).toHaveTextContent('An unexpected error occurred.');
+  });
+
+  test('handles empty messages gracefully', () => {
+    render(
+      <FlashProvider>
+        <TestComponent />
+      </FlashProvider>
+    );
+
+    act(() => {
+      screen.getByText('Process Empty Messages').click();
+    });
+
+    expect(screen.queryByTestId('flash-message')).toBeNull();
+  });
+
+  test('handles multiple flash types correctly', () => {
+    render(
+      <FlashProvider>
+        <TestComponent />
+      </FlashProvider>
+    );
+
+    act(() => {
+      screen.getByText('Process Multiple Flash Types').click();
+    });
+
+    // The last message processed should be the success message
+    expect(screen.getByTestId('flash-message')).toHaveTextContent('Second success');
+  });
+
+  test('throws an error when useFlash is used outside of FlashProvider', () => {
+    const ConsoleError = console.error;
+    console.error = jest.fn(); // Suppress expected error in test output
+
+    const TestWithoutProvider = () => {
+      useFlash();
+      return <div>Test</div>;
+    };
+
+    expect(() => render(<TestWithoutProvider />)).toThrow('useFlash must be used within a FlashProvider');
+
+    console.error = ConsoleError;
+  });
+
+  test('handles multiple flash messages in sequence', () => {
+    render(
+      <FlashProvider>
+        <TestComponent />
+      </FlashProvider>
+    );
+
+    act(() => {
+      screen.getByText('Set Success Flash').click();
+      screen.getByText('Set Warning Flash').click();
+    });
+
+    expect(screen.getByTestId('flash-message')).toHaveTextContent('Warning!');
+  });
+});

--- a/tests/hooks/useAccess.test.tsx
+++ b/tests/hooks/useAccess.test.tsx
@@ -1,5 +1,7 @@
+import { FlashContext, FlashContextType } from '../../src/contexts/FlashContext';
+import { act, renderHook } from '@testing-library/react';
+import React from 'react';
 import { apiRequest } from '../../src/hooks/apiRequest';
-import { renderHook } from '@testing-library/react';
 import { useAccess } from '../../src/hooks/useAccess';
 
 jest.mock('../../src/hooks/apiRequest', () => ({
@@ -7,8 +9,28 @@ jest.mock('../../src/hooks/apiRequest', () => ({
 }));
 
 describe('useAccess Hook', () => {
+  const mockProcessFlash = jest.fn();
+  const mockFlashContextValue: FlashContextType = {
+    flash: { message: '', type: 'info' },
+    setFlash: jest.fn(),
+    clearFlash: jest.fn(),
+    processFlash: mockProcessFlash,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.NEXT_PUBLIC_ACCESS_BASE_URL = 'https://mock-api.com';
+  });
+
+  // Wrapper to provide FlashContext
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <FlashContext.Provider value={mockFlashContextValue}>
+      {children}
+    </FlashContext.Provider>
+  );
+
   test('request calls apiRequest with correct parameters', async () => {
-    const { result } = renderHook(() => useAccess());
+    const { result } = renderHook(() => useAccess(), { wrapper });
     const { request } = result.current;
 
     const mockRequestBundle = {
@@ -22,17 +44,17 @@ describe('useAccess Hook', () => {
     const mockResponse = { data: 'test' };
     (apiRequest as jest.Mock).mockResolvedValue(mockResponse);
 
-    const response = await request(mockRequestBundle);
+    const response = await act(async () => request(mockRequestBundle));
 
     expect(apiRequest).toHaveBeenCalledWith(
-      `${process.env.NEXT_PUBLIC_ACCESS_BASE_URL}/test-endpoint`,
+      'https://mock-api.com/test-endpoint',
       mockRequestBundle.options
     );
     expect(response).toEqual(mockResponse);
   });
 
-  test('request handles errors correctly', async () => {
-    const { result } = renderHook(() => useAccess());
+  test('request handles API errors correctly and calls processFlash', async () => {
+    const { result } = renderHook(() => useAccess(), { wrapper });
     const { request } = result.current;
 
     const mockRequestBundle = {
@@ -43,9 +65,35 @@ describe('useAccess Hook', () => {
       },
     };
 
-    const mockError = new Error('Test error');
+    const mockErrorResponse = JSON.stringify({ flash: { error: ['API failure'] } });
+    (apiRequest as jest.Mock).mockRejectedValue(new Error(mockErrorResponse));
+
+    await act(async () => {
+      await expect(request(mockRequestBundle)).rejects.toThrow();
+    });
+
+    expect(mockProcessFlash).toHaveBeenCalledWith({ flash: { error: ['API failure'] } });
+  });
+
+  test('request handles unexpected errors correctly and calls processFlash', async () => {
+    const { result } = renderHook(() => useAccess(), { wrapper });
+    const { request } = result.current;
+
+    const mockRequestBundle = {
+      endpoint: '/test-endpoint',
+      options: {
+        method: 'GET' as const,
+        headers: { 'Content-Type': 'application/json' },
+      },
+    };
+
+    const mockError = new Error('Unexpected error');
     (apiRequest as jest.Mock).mockRejectedValue(mockError);
 
-    await expect(request(mockRequestBundle)).rejects.toThrow('Test error');
+    await act(async () => {
+      await expect(request(mockRequestBundle)).rejects.toThrow('Unexpected error');
+    });
+
+    expect(mockProcessFlash).toHaveBeenCalledWith({ flash: { error: ['An unexpected error occurred.'] } });
   });
 });

--- a/tests/hooks/useEntry.test.tsx
+++ b/tests/hooks/useEntry.test.tsx
@@ -1,3 +1,6 @@
+import { FlashContext } from '../../src/contexts/FlashContext';
+import React from 'react';
+import { ReactNode } from 'react';
 import { apiRequest } from '../../src/hooks/apiRequest';
 import { renderHook } from '@testing-library/react';
 import { useEntry } from '../../src/hooks/useEntry';
@@ -8,19 +11,24 @@ jest.mock('../../src/hooks/apiRequest', () => ({
 
 describe('useEntry Hook', () => {
   const mockJournalId = '12345';
+  const processFlash = jest.fn();
+
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <FlashContext.Provider value={{ flash: { type: 'info', message: '' }, setFlash: jest.fn(), clearFlash: jest.fn(), processFlash }}>{children}</FlashContext.Provider>
+  );
 
   beforeEach(() => {
-    (apiRequest as jest.Mock).mockClear();
+    jest.clearAllMocks();
   });
 
   test('throws error when journalId is not provided', () => {
     expect(() => {
-      renderHook(() => useEntry(''));
+      renderHook(() => useEntry(''), { wrapper });
     }).toThrow('journalId is required to use useEntry.');
   });
 
   test('request calls apiRequest with correct parameters', async () => {
-    const { result } = renderHook(() => useEntry(mockJournalId));
+    const { result } = renderHook(() => useEntry(mockJournalId), { wrapper });
     const { request } = result.current;
 
     const mockRequestBundle = {
@@ -44,8 +52,8 @@ describe('useEntry Hook', () => {
     expect(response).toEqual(mockResponse);
   });
 
-  test('request handles errors correctly', async () => {
-    const { result } = renderHook(() => useEntry(mockJournalId));
+  test('request handles errors correctly and triggers processFlash', async () => {
+    const { result } = renderHook(() => useEntry(mockJournalId), { wrapper });
     const { request } = result.current;
 
     const mockRequestBundle = {
@@ -57,14 +65,30 @@ describe('useEntry Hook', () => {
       },
     };
 
-    const mockError = new Error('Test error');
+    const mockError = new Error(JSON.stringify({ flash: { error: ['Test API error'] } }));
     (apiRequest as jest.Mock).mockRejectedValue(mockError);
 
-    await expect(request(mockRequestBundle)).rejects.toThrow('Test error');
+    await expect(request(mockRequestBundle)).rejects.toThrow(mockError);
+    expect(processFlash).toHaveBeenCalledWith({ flash: { error: ['Test API error'] } });
+  });
+
+  test('processFlash is triggered when response contains flash message', async () => {
+    const { result } = renderHook(() => useEntry(mockJournalId), { wrapper });
+    const { request } = result.current;
+
+    const mockResponse = { data: 'test', flash: { success: ['Success message'] } };
+    (apiRequest as jest.Mock).mockResolvedValue(mockResponse);
+
+    await request({ endpoint: '/flash-test', options: {
+      method: 'GET',
+      headers: {}
+    } });
+
+    expect(processFlash).toHaveBeenCalledWith(mockResponse);
   });
 
   test('request constructs URLs correctly with different endpoints', async () => {
-    const { result } = renderHook(() => useEntry(mockJournalId));
+    const { result } = renderHook(() => useEntry(mockJournalId), { wrapper });
     const { request } = result.current;
 
     const mockResponse = { data: 'test' };


### PR DESCRIPTION
### Description:

This PR introduces `FlashContext` to centralize flash messaging across the application. The goal is to automate flash message handling in API calls made via `useAccess` and `useEntry`, ensuring a consistent user experience when API responses contain success, error,  info or warning messages.

### Overview 
- Create `FlashContext` using provider pattern.
- Build `FlashComponent.tsx` using MUI Alert.
- Refactor `useAccess` and `useEntry` hooks to add flash support.
- Add theme overrides for MUI Alert.
- Add tests for `FlashContext` and `FlashComponent` functionality.
- Update `useAccess` and `useEntry` tests to cover flash message handling.

### How does it work?
- On a successful API response: If the response contains a flash message, it is automatically passed to `FlashContext`, which updates the UI.
- On an API error: If an error occurs, the flash message (if available) is extracted and displayed to the user.
- Similar behavior is expected if the API response comes with an `info` or `warning` flash message.
- This ensures that flash messages are handled centrally, without needing manual intervention in API-consuming components.

### How to test?
1.	Make an API request using any endpoint from the `accessApi`, for example: 
```
tsx 

import { ForgotPasswordBody, endpoints } from '../../hooks/api/accessApi';

const [formData, setFormData] = useState<ForgotPasswordBody>({
    email: '',
  });

const forgotPasswordRequest = endpoints['forgot-password'](formData);

```
3.	If the response contains a flash message, it should automatically appear in the UI.
4.	If the API call fails, the error flash message should be displayed.
5.	Run tests (`useAccess`, `useEntry`, and `FlashContext`) to verify flash message handling.

### Preview 

![image](https://github.com/user-attachments/assets/1646e373-0a7a-4102-9b04-7e2a80a2791a)
![image](https://github.com/user-attachments/assets/acc064db-21e6-415e-96c6-44767e4990b2)

![image](https://github.com/user-attachments/assets/e9465df2-052c-4632-8d3c-ca41e8c42638)

